### PR TITLE
Show application header

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -69,13 +69,19 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
 }
 
 header h1 {
-    font-size: 1.75rem;
+    font-size: 1.25rem;
     font-weight: 700;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     -webkit-background-clip: text;
@@ -85,9 +91,9 @@ header h1 {
 }
 
 .subtitle {
-    font-size: 0.95rem;
+    font-size: 0.875rem;
     color: var(--text-secondary);
-    margin-top: 0.5rem;
+    margin: 0;
 }
 
 /* Main Content Area with Sidebar */


### PR DESCRIPTION
Show and style the application header that was previously hidden via `display: none` in style.css.

Closes #2

Generated with [Claude Code](https://claude.ai/code)